### PR TITLE
Create BPA cards

### DIFF
--- a/app/atcCardMove.js
+++ b/app/atcCardMove.js
@@ -1,0 +1,62 @@
+"use strict";
+const util = require('../util');
+const log = util.getLogger('atc card move');
+const Trello = require('node-trello');
+const bpa = require('bpa-trello-dashboard/app');
+
+function isMoveCardAction(action) {
+  return (action.type === 'updateCard' && action.data.listAfter && action.data.listBefore);
+}
+
+function addBpaCardsForAtc(cardID) {
+  return new Promise(resolve => {
+    let trello = new Trello(process.env.TRELLO_API_KEY, process.env.TRELLO_API_TOK);
+    const bpaCardCreator = new bpa.CardCreator(null, process.env.BPA_TRELLO_BOARD_ID);
+
+    trello.get(`/1/cards/${cardID}`, (err, card) => {
+      if(err) {
+        log.error('Error getting Trello card');
+        log.error(err);
+        resolve();
+        return;
+      }
+
+      // If one of the "BPA: " lines of the description already
+      // has a link, don't need to create another card.
+      const bpasNeeded = card.desc.match(/BPA:([^\n]+)/gi).filter(bpa => bpa.indexOf("https://trello.com") < 0);
+      const bpaPromises = [ ];
+
+      for(const bpa of bpasNeeded) {
+        bpaPromises.push(
+          bpaCardCreator.createCard({
+            project: card.name,
+            order: bpa.substr(4).trim(),
+            trello: card.shortUrl
+          }).then(bpaCard => {
+            card.desc = card.desc.replace(bpa, `BPA: ${bpaCard.url}`);
+            trello.put(`/1/card/${card.id}`, card, () => { });
+          }).catch(err => {
+            log.error('Error creating BPA card');
+            log.error(err);
+          })
+        );
+      }
+
+      Promise.all(bpaPromises).then(() => resolve());
+    });
+  });
+}
+
+module.exports = function(e) {
+  if(isMoveCardAction(e.action)) {
+    if(e.action.data.listAfter.name === 'In Flight') {
+      log.verbose('Card was moved to In Flight');
+      return addBpaCardsForAtc(e.action.data.card.id).then(() => e);
+    }
+  }
+
+  // If it wasn't a move, or the card wasn't
+  // moved to In Flight, just return a resolved
+  // promise so the chain can continue.
+  return Promise.resolve(e);
+}

--- a/app/atcCardMove.js
+++ b/app/atcCardMove.js
@@ -1,4 +1,5 @@
 "use strict";
+
 const util = require('../util');
 const log = util.getLogger('atc card move');
 const Trello = require('node-trello');
@@ -23,7 +24,12 @@ function addBpaCardsForAtc(cardID) {
 
       // If one of the "BPA: " lines of the description already
       // has a link, don't need to create another card.
-      const bpasNeeded = card.desc.match(/BPA:([^\n]+)/gi).filter(bpa => bpa.indexOf("https://trello.com") < 0);
+      let bpasNeeded = card.desc.match(/BPA:([^\n]+)/gi);
+      if(bpasNeeded) {
+        bpasNeeded = bpasNeeded.filter(bpa => bpa.indexOf("https://trello.com") < 0);
+      } else {
+        bpasNeeded = [ ];
+      }
       const bpaPromises = [ ];
 
       for(const bpa of bpasNeeded) {

--- a/app/index.js
+++ b/app/index.js
@@ -1,0 +1,6 @@
+module.exports = {
+  webhookServer: require('./webhookServer'),
+  handlers: [
+    require('./atcCardMove')
+  ]
+};

--- a/app/webhookServer.js
+++ b/app/webhookServer.js
@@ -3,7 +3,7 @@
 const Trello = require('node-trello');
 const http = require('http');
 const crypto = require('crypto');
-const util = require('./util');
+const util = require('../util');
 const log = util.getLogger('webhook server');
 
 function verifyTrelloWebhookRequest(hostname, body, signature) {

--- a/index.js
+++ b/index.js
@@ -9,42 +9,6 @@ const log = util.getLogger('main');
 
 const trelloWHServer = new WebhookServer(PORT);
 
-/*
-function isMoveCardAction(action) {
-  return (action.type === 'updateCard' && action.data.listAfter && action.data.listBefore);
-}
-
-const bpaCardCreator = new bpa.CardCreator(null, process.env.BPA_TRELLO_BOARD_ID);
-
-function addBpaCardsForAtc(cardID) {
-  let trello = new Trello(process.env.TRELLO_API_KEY, process.env.TRELLO_API_TOK);
-  trello.get(`/1/cards/${cardID}`, (err, card) => {
-    if(err) {
-      log.error('Error getting Trello card');
-      log.error(err);
-      return;
-    }
-
-    // If one of the "BPA: " lines of the description already
-    // has a link, don't need to create another card.
-    const bpasNeeded = card.desc.match(/BPA:([^\n]+)/gi).filter(bpa => bpa.indexOf("https://trello.com") < 0);
-    for(const bpa of bpasNeeded) {
-      bpaCardCreator.createCard({
-        project: card.name,
-        order: bpa.substr(4).trim(),
-        trello: card.shortUrl
-      }).then(bpaCard => {
-        card.desc = card.desc.replace(bpa, `BPA: ${bpaCard.url}`);
-        trello.put(`/1/card/${card.id}`, card, () => { });
-      }).catch(err => {
-        log.error('Error creating BPA card');
-        log.error(err);
-      });
-    }
-  });
-}
-*/
-
 trelloWHServer.start().then(s => s.on('data', e => {
   let promise = null;
   for(let handler of app.handlers) {
@@ -54,12 +18,6 @@ trelloWHServer.start().then(s => s.on('data', e => {
       promise = handler(e)
     }
   }
-  /*if(isMoveCardAction(e.action)) {
-    if(e.action.data.listAfter.name === 'In Flight') {
-      log.verbose('Card was moved to In Flight');
-      addBpaCardsForAtc(e.action.data.card.id);
-    }
-  }*/
 })).catch(e => {
   log.error('Error starting Trello webhook server');
   log.error(e);

--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 'use strict';
 
 require('dotenv').config();
+const Trello = require('node-trello');
 const bpa = require('bpa-trello-dashboard/app');
 const PORT = process.env.PORT || 5000;
 const WebhookServer = require('./webhookServer');
@@ -8,16 +9,46 @@ const util = require('./util');
 const log = util.getLogger('main');
 
 const trelloWHServer = new WebhookServer(PORT);
-//trelloWHServer.start();
 
 function isMoveCardAction(action) {
   return (action.type === 'updateCard' && action.data.listAfter && action.data.listBefore);
+}
+
+const bpaCardCreator = new bpa.CardCreator(null, process.env.BPA_TRELLO_BOARD_ID);
+
+function addBpaCardsForAtc(cardID) {
+  let trello = new Trello(process.env.TRELLO_API_KEY, process.env.TRELLO_API_TOK);
+  trello.get(`/1/cards/${cardID}`, (err, card) => {
+    if(err) {
+      log.error('Error getting Trello card');
+      log.error(err);
+      return;
+    }
+
+    // If one of the "BPA: " lines of the description already
+    // has a link, don't need to create another card.
+    const bpasNeeded = card.desc.match(/BPA:([^\n]+)/gi).filter(bpa => bpa.indexOf("https://trello.com") < 0);
+    for(const bpa of bpasNeeded) {
+      bpaCardCreator.createCard({
+        project: card.name,
+        order: bpa.substr(4).trim(),
+        trello: card.shortUrl
+      }).then(bpaCard => {
+        card.desc = card.desc.replace(bpa, `BPA: ${bpaCard.url}`);
+        trello.put(`/1/card/${card.id}`, card, () => { });
+      }).catch(err => {
+        log.error('Error creating BPA card');
+        log.error(err);
+      });
+    }
+  });
 }
 
 trelloWHServer.start().then(s => s.on('data', e => {
   if(isMoveCardAction(e.action)) {
     if(e.action.data.listAfter.name === 'In Flight') {
       log.verbose('Card was moved to In Flight');
+      addBpaCardsForAtc(e.action.data.card.id);
     }
   }
 })).catch(e => {
@@ -33,73 +64,3 @@ function cleanup() {
 process.on('SIGINT', cleanup);
 process.on('SIGTERM', cleanup);
 process.on('exit', () => { });
-
-//const stageManager = new bpa.StageManager('runtime/bpa-stages.yaml', process.env.TRELLO_BPA_BOARD_ID);
-//stageManager.run();
-
-//const cardCreator = new bpa.CardCreator(null, process.env.TRELLO_BPA_BOARD_ID);
-
-/* * /
-const http = require('http');
-const webhookListener = http.createServer((req, res) => {
-  if(req.method.toLowerCase() === 'post' || req.method.toLowerCase() === 'put') {
-    let trelloEvent = '';
-    log.verbose('Got a webhook event');
-
-    req.on('data', chunk => trelloEvent += chunk);
-    req.on('end', () => {
-      if(!verifyTrelloWebhookRequest(trelloEvent, req.headers['x-trello-webhook'])) {
-        log.error('TRELLO SIGNATURE VERIFICATION FAILED');
-        return;
-      }
-      log.verbose('Valid Trello webhook event');
-
-      trelloEvent = JSON.parse(trelloEvent);
-
-      if(trelloEvent.action.type === 'updateCard') {
-        if(trelloEvent.action.data.listAfter && trelloEvent.action.data.listBefore) {
-          // Card was moved
-          if(trelloEvent.action.data.listAfter.name === 'In Flight') {
-            console.log('Card was moved to In Flight');
-
-            /* * /
-            t.get(`/1/cards/${tEvent.action.data.card.id}`, (err, card) => {
-              const bpas = card.desc.match(/BPA:([^\n]+)/gi).filter(bpa => bpa.indexOf("https://trello.com") < 0);
-
-              const allBPACardPromises = [ ];
-              for(let bpa of bpas) {
-                allBPACardPromises.push(new Promise((bpaCardResolve, bpaCardReject) => {
-                  cardCreator.createCard({
-                    project: card.name,
-                    order: bpa.substr(4).trim()
-                  }).then(bpaCard => {
-                    card.desc = card.desc.replace(bpa, `${bpa} ${bpaCard.url}`);
-                    bpaCard.desc = bpaCard.desc.replace(`Project: ${card.name}`, `Project: ${card.url}`);
-                    t.put(`/1/card/${bpaCard.id}`, bpaCard, () => { });
-                    bpaCardResolve();
-                  }).catch(err => {
-                    console.log(err);
-                    bpaCardResolve();
-                  });
-                }));
-              }
-
-              Promise.all(allBPACardPromises).then(() => {
-                t.put(`/1/card/${card.id}`, card, (updateErr, data) => {
-                  console.log(updateErr);
-                  console.log(data);
-                });
-              });
-            });
-            //* /
-          }
-        }
-      }
-
-      res.end();
-    })
-  } else {
-    res.end();
-  }
-});
-//*/

--- a/test/test-atc-card-move.js
+++ b/test/test-atc-card-move.js
@@ -1,0 +1,172 @@
+"use strict";
+
+const tap = require('tap');
+const sinon = require('sinon');
+const trello = require('node-trello');
+const bpa = require('bpa-trello-dashboard/app');
+const common = require('./common');
+const util = require('../util');
+const atcCardMove = require('../app/atcCardMove');
+
+tap.test('ATC Card Move handler', t1 => {
+  const sandbox = sinon.sandbox.create();
+
+  t1.beforeEach(done => {
+    common.resetEnvVars();
+    sandbox.restore();
+    done();
+  });
+
+  const doTest = function(e, test, done) {
+    console.log('doTest');
+    if(!done) {
+      done = () => null;
+    }
+    return atcCardMove(e)
+      .then(eResolved => {
+        test.equal(eResolved, e, 'resolves the event object');
+        test.pass('resolves');
+        done();
+        console.log('doTest.then');
+      })
+      .catch(() => {
+        test.fail('resolves');
+        done();
+        console.log('doTest.catch');
+      });
+  };
+
+  t1.test('When card is not moved', t2 => {
+
+    t2.test('Action is not a card update', t3 => {
+      const e = {
+        action: {
+          type: 'not-update',
+          data: {
+            listAfter: { },
+            listBefore: { }
+          }
+        }
+      };
+      doTest(e, t3, t3.end);
+    });
+
+    t2.test('No listAfter property', t3 => {
+      const e = {
+        action: {
+          type: 'updateCard',
+          data: {
+            listBefore: { }
+          }
+        }
+      };
+      doTest(e, t3, t3.end);
+    });
+
+    t2.test('No listBefore property', t3 => {
+      const e = {
+        action: {
+          type: 'updateCard',
+          data: {
+            listAfter: { }
+          }
+        }
+      };
+      doTest(e, t3, t3.end);
+    });
+
+    t2.end();
+  });
+
+  t1.test('When card is moved', t2 => {
+    t2.test('Not moved to In Flight', t3 => {
+      const e = {
+        action: {
+          type: 'updateCard',
+          data: {
+            listAfter: { name: 'Wrong list' },
+            listBefore: { }
+          }
+        }
+      };
+      doTest(e, t3, t3.end);
+    });
+
+    t2.test('Moved to In Flight', t3 => {
+      const e = {
+        action: {
+          type: 'updateCard',
+          data: {
+            listAfter: { name: 'In Flight' },
+            listBefore: { },
+            card: {
+              id: 'card-id'
+            }
+          }
+        }
+      };
+
+      let trelloGet, trelloPut;
+      let createCard;
+
+      t2.beforeEach(done => {
+        process.env.TRELLO_API_KEY = 'trello-api-key';
+        process.env.TRELLO_API_TOK = 'trello-api-token';
+        process.env.BPA_TRELLO_BOARD_ID = 'bpa-trello-board-id';
+
+        trelloGet = sandbox.stub(trello.prototype, 'get');
+        trelloPut = sandbox.stub(trello.prototype, 'put');
+        createCard = sandbox.stub(bpa.CardCreator.prototype, 'createCard');
+        done();
+      });
+
+      t3.test('There is an error getting the card from Trello', t4 => {
+        trelloGet.yields(new Error('Test Error'), null);
+        doTest(e, t4).then(() => {
+          t4.equal(trelloGet.callCount, 1, 'calls Trello get once');
+          t4.end();
+        });
+      });
+
+      t3.test('Trello returns a valid card with no BPA orders', t4 => {
+        trelloGet.yields(null, { desc: '' });
+        doTest(e, t4).then(() => {
+          t4.equal(trelloGet.callCount, 1, 'calls Trello get once');
+          t4.end();
+        });
+      });
+
+      t3.test('Trello returns a valid card with 3 BPA orders', t4 => {
+        t4.test('BPA create card fails', t5 => {
+          trelloGet.yields(null, { desc: 'BPA: Order 1\nBPA: Order 2\nBPA: Order 3' });
+          createCard.rejects(new Error('Test Error'));
+          doTest(e, t5).then(() => {
+            t5.equal(trelloGet.callCount, 1, 'calls Trello get once');
+            t5.equal(createCard.callCount, 3, 'calls createCard 3 times');
+            t5.equal(trelloPut.callCount, 0, 'calls Trello put 0 times');
+            t5.end();
+          });
+        });
+
+        t4.test('BPA create card succeeds', t5 => {
+          trelloGet.yields(null, { desc: 'BPA: Order 1\nBPA: Order 2\nBPA: Order 3' });
+          createCard.resolves({ url: 'some-url' });
+          doTest(e, t5).then(() => {
+            t5.equal(trelloGet.callCount, 1, 'calls Trello get once');
+            t5.equal(createCard.callCount, 3, 'calls createCard 3 times');
+            t5.equal(trelloPut.callCount, 3, 'calls Trello put 3 times');
+            t5.end();
+          });
+        });
+
+        t4.end();
+      });
+
+      t3.end();
+    });
+
+    t2.end();
+  });
+
+  t1.end();
+});

--- a/test/test-webhook-server.js
+++ b/test/test-webhook-server.js
@@ -7,7 +7,7 @@ const crypto = require('crypto');
 const trello = require('node-trello');
 const common = require('./common');
 const util = require('../util');
-const webhookServer = require('../webhookServer');
+const webhookServer = require('../app').webhookServer;
 
 tap.test('Webhook server class', t1 => {
   const sandbox = sinon.sandbox.create();


### PR DESCRIPTION
Refactors a bit, and adds functionality to create BPA cards when an ATC card moves to the In Flight list, if the ATC card has a BPA order in its description.

In order for this to work, the ATC card's description must contain text identifying the BPA order like so:

```
BPA: order name
```

An ATC card can have multiple BPA orders associated with it, but each must be on a line by itself.  When the ATC card is moved to "In Flight," cards will be added to the BPA board for each BPA order in the ATC card.  The ATC card will then be updated to include links to the BPA order cards.
